### PR TITLE
Creates FunctionOperator, a useful wrapper for operators defined by generic functions

### DIFF
--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -17,7 +17,6 @@ class LinearOperator(spLinearOperator):
 
     """
     def __init__(self, explicit=False):
-        super(LinearOperator, self).__init__()
         self.explicit = explicit
 
     def div(self, y):

--- a/pylops/__init__.py
+++ b/pylops/__init__.py
@@ -8,6 +8,8 @@ from .basicoperators import Diagonal
 from .basicoperators import Flip
 from .basicoperators import Symmetrize
 
+from .basicoperators import FunctionOperator
+
 from .basicoperators import VStack
 from .basicoperators import HStack
 from .basicoperators import Block

--- a/pylops/basicoperators/FunctionOperator.py
+++ b/pylops/basicoperators/FunctionOperator.py
@@ -90,7 +90,6 @@ class FunctionOperator(LinearOperator):
             self.fc = args[0]
             self.shape = args[1:3]
 
-    
     def _matvec(self, x):
         return self.f(x)
 

--- a/pylops/basicoperators/FunctionOperator.py
+++ b/pylops/basicoperators/FunctionOperator.py
@@ -1,0 +1,102 @@
+import numpy as np
+from numbers import Integral
+from pylops import LinearOperator
+
+
+class FunctionOperator(LinearOperator):
+    r"""Function Operator.
+
+    Simple wrapper to functions for forward `f` and adjoint `fc`
+    multiplication.
+
+    Functions :math:`f` and :math:`fc` respect
+    :math:`f:\mathbb{F}^n \to \mathbb{F}^m` and
+    :math:`fc:\mathbb{F}^m \to \mathbb{F}^n` where :math:`\mathbb{F}` is
+    the appropriate underlying type.
+
+    Parameters
+    ----------
+    f : :obj:`callable`
+        Function for forward multiplication.
+    fc : :obj:`callable`, optional
+        Function for adjoint multiplication.
+    nr : :obj:`int`
+        Number of "rows" (length of output vector).
+    nc : :obj:`int`, optional
+        Number of "columns" (length of input vector).
+    dtype : :obj:`str`, optional
+        Type of elements in input array.
+
+    It can be called in the following ways:
+
+    FunctionOperator(f, n)
+    FunctionOperator(f, nr, nc)
+    FunctionOperator(f, fc, nc)
+    FunctionOperator(f, fc, nr, nc)
+
+    The first two methods will return `NotImplementedError` is the adjoint is
+    The first and third method assume the matrix (or matrices) are square.
+    called.
+    All methods can be called with the `dtype` keyword argument.
+
+    Attributes
+    ----------
+    shape : :obj:`tuple`
+        Operator shape (nr, nc)
+    explicit : :obj:`bool`
+        Operator contains a matrix that can be solved explicitly (``True``) or
+        not (``False``)
+
+    Examples
+    --------
+    >>> from pylops.basicoperators import FunctionOperator
+    >>> def forward(v):
+    ...     return np.array([2*v[0], 3*v[1]])
+    ...
+    >>> A = FunctionOperator(forward, 2)
+    >>> A
+    <11x11 FunctionOperator with dtype=float64>
+    >>> A.matvec(np.ones(2))
+    array([2.,  3.])
+    >>> A @ np.ones(2)
+    array([2.,  3.])
+    """
+
+    def __init__(self, f, *args, **kwargs):
+        try:
+            self.dtype = kwargs['dtype']
+        except KeyError:
+            self.dtype = 'float64'
+        self.explicit = False
+
+        super().__init__()
+
+        self.f = f
+
+        # call is FunctionOperator(f, m)
+        if len(args) == 1:
+            self.shape = (args[0], args[0])
+            self.fc = None
+        elif len(args) == 2:
+            # call is FunctionOperator(f, m, n)
+            if isinstance(args[0], Integral):
+                self.shape = (args[0], args[1])
+                self.fc = None
+            # call is FunctionOperator(f, fc, n)
+            else:
+                self.fc = args[0]
+                self.shape = (args[1], args[1])
+        # call is FunctionOperator(f, fc, m, n)
+        elif len(args) == 3:
+            self.fc = args[0]
+            self.shape = args[1:3]
+
+    
+    def _matvec(self, x):
+        return self.f(x)
+
+    def _rmatvec(self, x):
+        if self.fc is None:
+            raise NotImplementedError("Adjoint not implemented")
+        else:
+            return self.fc(x)

--- a/pylops/basicoperators/FunctionOperator.py
+++ b/pylops/basicoperators/FunctionOperator.py
@@ -1,4 +1,3 @@
-import numpy as np
 from numbers import Integral
 from pylops import LinearOperator
 

--- a/pylops/basicoperators/__init__.py
+++ b/pylops/basicoperators/__init__.py
@@ -4,6 +4,7 @@ from .MatrixMult import MatrixMult
 from .Diagonal import Diagonal
 from .Zero import Zero
 from .Identity import Identity
+from .FunctionOperator import FunctionOperator
 from .Restriction import Restriction
 from .Flip import Flip
 from .Symmetrize import Symmetrize

--- a/pytests/test_functionoperator.py
+++ b/pytests/test_functionoperator.py
@@ -66,8 +66,8 @@ def test_FunctionOperator(par):
     assert_array_equal(F_x, G_x)
     assert_array_equal(FH_y, GH_y)
 
-    # Only test inversion for square or overdetermined systems
-    if par['nr'] <= par['nc']:
+    # Only test inversion for square or underdetermined systems
+    if par['nc'] <= par['nr']:
         xlsqr = lsqr(Fop, F_x, damp=0, iter_lim=100, show=0)[0]
         assert_array_almost_equal(x, xlsqr, decimal=4)
 

--- a/pytests/test_functionoperator.py
+++ b/pytests/test_functionoperator.py
@@ -66,7 +66,7 @@ def test_FunctionOperator(par):
     assert_array_equal(F_x, G_x)
     assert_array_equal(FH_y, GH_y)
 
-    # Only test inversion for square or underdetermined systems
+    # Only test inversion for square or overdetermined systems
     if par['nc'] <= par['nr']:
         xlsqr = lsqr(Fop, F_x, damp=0, iter_lim=100, show=0)[0]
         assert_array_almost_equal(x, xlsqr, decimal=4)

--- a/pytests/test_functionoperator.py
+++ b/pytests/test_functionoperator.py
@@ -1,0 +1,123 @@
+"""
+test_functionoperator.py
+
+Test module for FunctionOperator. Tests 32 and 64 bit float and complex number
+by wrapping a matrix multiplication as a FunctionOperator.
+Also provides a good starting point for new tests.
+"""
+import itertools
+import pytest
+
+import numpy as np
+from numpy.testing import assert_array_equal, assert_array_almost_equal
+from scipy.sparse.linalg import lsqr
+
+from pylops.utils import dottest
+from pylops.basicoperators import FunctionOperator
+
+PARS_LISTS = [
+        [11, 21],  # nr
+        [11, 21],  # nc
+        ['float32', 'float64', 'complex64', 'complex128'],  # dtypes
+        ]
+PARS = []
+for nr, nc, dtype in itertools.product(*PARS_LISTS):
+    PARS += [{'nr': nr,
+              'nc': nc,
+              'imag': 0 if dtype.startswith('float') else 1j,
+              'dtype': dtype}]
+
+
+@pytest.mark.parametrize("par", PARS)
+def test_FunctionOperator(par):
+    """Dot-test and inversion for FunctionOperator operator.
+    """
+    np.random.seed(10)
+    G = np.matrix(np.random.normal(0, 1, (par['nr'], par['nc'])) +
+                  np.random.normal(0, 1, (par['nr'], par['nc']))*par['imag'],
+                  dtype=par['dtype'])
+
+    def forward_f(x):
+        return G @ x
+    def adjoint_f(y):
+        return G.H @ y
+
+    if par['nr'] == par['nc']:
+        Fop = FunctionOperator(forward_f, adjoint_f, par['nr'],
+                               dtype=par['dtype'])
+    else:
+        Fop = FunctionOperator(forward_f, adjoint_f, par['nr'], par['nc'],
+                               dtype=par['dtype'])
+
+    assert dottest(Fop, par['nr'], par['nc'],
+                   complexflag=0 if par['imag'] == 0 else 3)
+
+    x = (np.ones(par['nc']) +
+         np.ones(par['nc'])*par['imag']).astype(par['dtype'])
+    y = (np.ones(par['nr']) +
+         np.ones(par['nr'])*par['imag']).astype(par['dtype'])
+
+    F_x = Fop @ x
+    FH_y = Fop.H @ y
+
+    G_x = np.squeeze(np.asarray(G @ x))
+    GH_y = np.squeeze(np.asarray(G.H @ y))
+
+    assert_array_equal(F_x, G_x)
+    assert_array_equal(FH_y, GH_y)
+
+    # Only test inversion for square or overdetermined systems
+    if par['nr'] <= par['nc']:
+        xlsqr = lsqr(Fop, F_x, damp=0, iter_lim=100, show=0)[0]
+        assert_array_almost_equal(x, xlsqr, decimal=4)
+
+
+@pytest.mark.parametrize("par", PARS)
+def test_FunctionOperator_NoAdjoint(par):
+    """Dot-test and inversion for FunctionOperator operator where the adjoint
+is not implemented.
+    """
+    np.random.seed(10)
+    G = np.matrix(np.random.normal(0, 1, (par['nr'], par['nc'])) +
+                  np.random.normal(0, 1, (par['nr'], par['nc']))*par['imag'],
+                  dtype=par['dtype'])
+
+    def forward_f(x):
+        return G @ x
+
+    if par['nr'] == par['nc']:
+        Fop = FunctionOperator(forward_f, par['nr'], dtype=par['dtype'])
+    else:
+        Fop = FunctionOperator(forward_f, par['nr'], par['nc'],
+                               dtype=par['dtype'])
+
+    x = (np.ones(par['nc']) +
+         np.ones(par['nc'])*par['imag']).astype(par['dtype'])
+    y = (np.ones(par['nr']) +
+         np.ones(par['nr'])*par['imag']).astype(par['dtype'])
+
+    F_x = Fop @ x
+    try:
+        Fop.H @ y
+    except NotImplementedError:
+        pass
+
+    G_x = np.squeeze(np.asarray(G @ x))
+    assert_array_equal(F_x, G_x)
+
+
+if __name__ == '__main__':
+    print("With adjoints")
+    for p in PARS:
+        try:
+            test_FunctionOperator(p)
+            print("{0: <60}PASSED".format(str(p)))
+        except AssertionError:
+            print("{0: <60}FAILED".format(str(p)))
+    print("\nWithout adjoints")
+    for p in PARS:
+        try:
+            test_FunctionOperator_NoAdjoint(p)
+            print("{0: <60}PASSED".format(str(p)))
+        except AssertionError:
+            print("{0: <60}FAILED".format(str(p)))


### PR DESCRIPTION
Create LinearOperators quickly by calling:

    FunctionOperator(f, n)
    FunctionOperator(f, nr, nc)
    FunctionOperator(f, fc, nc)

or

    FunctionOperator(f, fc, nr, nc)
