### PR TITLE
Properly implement scooby

### DIFF
--- a/pylops/__init__.py
+++ b/pylops/__init__.py
@@ -41,6 +41,7 @@ from .optimization.sparsity import IRLS, ISTA, FISTA, SPGL1, SplitBregman
 from .utils.seismicevents import makeaxis, linear2d, parabolic2d
 from .utils.tapers import hanningtaper, cosinetaper, taper2d, taper3d
 from .utils.wavelets import ricker, gaussian
+from .utils.utils import Report
 
 from . import avo
 from . import basicoperators

--- a/pylops/utils/__init__.py
+++ b/pylops/utils/__init__.py
@@ -1,1 +1,2 @@
+from .utils import Report
 from .dottest import dottest

--- a/pylops/utils/utils.py
+++ b/pylops/utils/utils.py
@@ -1,0 +1,71 @@
+# scooby is a soft dependency for pylops
+try:
+    from scooby import Report as ScoobyReport
+except ImportError:
+    class ScoobyReport:
+        def __init__(self, additional, core, optional, ncol, text_width, sort):
+            print("\nNOTE: `pylops.Report` requires `scooby`. Install it via"
+                  "\n      `pip install scooby` or "
+                  "`conda install -c conda-forge scooby`.\n")
+
+
+class Report(ScoobyReport):
+    r"""Print date, time, and version information.
+
+    Use ``scooby`` to print date, time, and package version information in any
+    environment (Jupyter notebook, IPython console, Python console, QT
+    console), either as html-table (notebook) or as plain text (anywhere).
+
+    Always shown are the OS, number of CPU(s), ``numpy``, ``scipy``,
+    ``pylops``, ``sys.version``, and time/date.
+
+    Additionally shown are, if they can be imported, ``IPython``, ``numba``,
+    and ``matplotlib``. It also shows MKL information, if available.
+
+    All modules provided in ``add_pckg`` are also shown.
+
+    .. note::
+
+        The package ``scooby`` has to be installed in order to use ``Report``:
+        ``pip install scooby`` or ``conda install -c conda-forge scooby``.
+
+
+    Parameters
+    ----------
+    add_pckg : packages, optional
+        Package or list of packages to add to output information (must be
+        imported beforehand).
+
+    ncol : int, optional
+        Number of package-columns in html table (no effect in text-version);
+        Defaults to 3.
+
+    text_width : int, optional
+        The text width for non-HTML display modes
+
+    sort : bool, optional
+        Sort the packages when the report is shown
+
+
+    Examples
+    --------
+    >>> import pytest
+    >>> import dateutil
+    >>> from pylops import Report
+    >>> Report()                            # Default values
+    >>> Report(pytest)                      # Provide additional package
+    >>> Report([pytest, dateutil], ncol=5)  # Set nr of columns
+
+    """
+
+    def __init__(self, add_pckg=None, ncol=3, text_width=80, sort=False):
+        """Initiate a scooby.Report instance."""
+
+        # Mandatory packages.
+        core = ['numpy', 'scipy', 'pylops']
+
+        # Optional packages.
+        optional = ['IPython', 'matplotlib', 'numba']
+
+        super().__init__(additional=add_pckg, core=core, optional=optional,
+                         ncol=ncol, text_width=text_width, sort=sort)

--- a/pytests/test_utils.py
+++ b/pytests/test_utils.py
@@ -1,0 +1,26 @@
+from pylops import utils
+
+# Optional import
+try:
+    import scooby
+except ImportError:
+    scooby = False
+
+
+def test_report(capsys):
+    out, _ = capsys.readouterr()  # Empty capsys
+
+    # Reporting is done by the external package scooby.
+    # We just ensure the shown packages do not change (core and optional).
+    if scooby:
+        out1 = utils.Report()
+        out2 = scooby.Report(core=['numpy', 'scipy', 'pylops'],
+                             optional=['IPython', 'matplotlib', 'numba'])
+
+        # Ensure they're the same; exclude time to avoid errors.
+        assert out1.__repr__()[115:] == out2.__repr__()[115:]
+
+    else:  # soft dependency
+        _ = utils.Report()
+        out, _ = capsys.readouterr()  # Empty capsys
+        assert 'NOTE: `pylops.Report` requires `scooby`. Install it via' in out


### PR DESCRIPTION
This implements the `scooby.Report` properly into `pylops`.

Instead of
```
import scooby
scooby.Report(pylops)
```
you can now simply do
```
pylops.Report()
```

The package `scooby` is not a dependency though. If it is not installed, and `pylops.Report()` is called, it will simply print:
```

NOTE: `pylops.Report` requires `scooby`. Install it via
      `pip install scooby` or `conda install -c conda-forge scooby`.

```