### PR TITLE
[Core] Mathematical operations return LinearOperator

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ operators that can be tailored to our needs, and as contribution to the free sof
 When using ``pylops`` in scientific publications, please cite the following paper:
 
 - Ravasi, M., and Vasconcelos I., *PyLops--A Linear-Operator Python Library for large scale optimization*,
-  arXiv preprint, [arXiv:1907.12349](https://arxiv.org/abs/1907.12349)  (2019).
+  SoftwareX, (2019). [link](https://www.sciencedirect.com/science/article/pii/S2352711019301086).
+
+
 
 ## Contributors
 * Matteo Ravasi, mrava87

--- a/docs/source/citing.rst
+++ b/docs/source/citing.rst
@@ -5,5 +5,4 @@ Citing
 When using ``pylops`` in scientific publications, please cite the following paper:
 
 - Ravasi, M., and Vasconcelos I., *PyLops--A Linear-Operator Python Library for large scale optimization*,
-  arXiv preprint, `arXiv:1907.12349 <https://arxiv.org/abs/1907.12349>`_ (2019).
-
+  Software X, (2019). `link <https://www.sciencedirect.com/science/article/pii/S2352711019301086>`_.

--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -59,6 +59,30 @@ class LinearOperator(spLinearOperator):
         """
         return np.vstack([self.matvec(col.reshape(-1)) for col in X.T]).T
 
+    def __mul__(self, x):
+        y = super().__mul__(x)
+        if isinstance(y, spLinearOperator):
+            y = LinearOperator(y)
+        return y
+
+    def __rmul__(self, x):
+        return LinearOperator(super().__rmul__(x))
+
+    def __pow__(self, p):
+        return LinearOperator(super().__pow__(p))
+
+    def __add__(self, x):
+        return LinearOperator(super().__add__(x))
+
+    def __neg__(self):
+        return LinearOperator(super().__neg__())
+
+    def __sub__(self, x):
+        return LinearOperator(super().__sub__(x))
+
+    def _adjoint(self):
+        return LinearOperator(super()._adjoint())
+
     def div(self, y, niter=100):
         r"""Solve the linear problem :math:`\mathbf{y}=\mathbf{A}\mathbf{x}`.
 
@@ -94,7 +118,7 @@ class LinearOperator(spLinearOperator):
             xest = lsqr(self, y, iter_lim=niter)[0]
         return xest
 
-    def dense(self):
+    def todense(self):
         r"""Return dense matrix.
 
         The operator in converted into its dense matrix equivalent. In order

--- a/pylops/basicoperators/Kronecker.py
+++ b/pylops/basicoperators/Kronecker.py
@@ -30,7 +30,7 @@ class Kronecker(LinearOperator):
 
     Notes
     -----
-    The Kronecker product denoted with :math`\otimes` is an operation
+    The Kronecker product (denoted with :math:`\otimes`) is an operation
     on two operators :math:`\mathbf{Op_1}` and :math:`\mathbf{Op_2}` of
     sizes :math:`\lbrack n_1 \times m_1 \rbrack` and
     :math:`\lbrack n_2 \times m_2 \rbrack` respectively, resulting in a
@@ -46,13 +46,12 @@ class Kronecker(LinearOperator):
 
     The application of the resulting matrix to a vector :math:`\mathbf{x}` of
     size :math:`\lbrack m_1 m_2 \times 1 \rbrack` is equivalent to the
-    application of the second operator :math:`\mathbf{Op_2}` to the columns of
+    application of the second operator :math:`\mathbf{Op_2}` to the rows of
     a matrix of size :math:`\lbrack m_2 \times m_1 \rbrack` obtained by
     reshaping the input vector :math:`\mathbf{x}`, followed by the application
     of the first operator to the transposed matrix produced by the first
-    operator. Similarly, in adjoint mode the two operators are applied in
-    reversed order to a reshaped matrix of size
-    :math:`\lbrack n_1 \times n_2 \rbrack`.
+    operator. In adjoint mode the same procedure is followed but the adjoint of
+    each operator is used.
 
     """
     def __init__(self, Op1, Op2, dtype='float64'):
@@ -66,13 +65,13 @@ class Kronecker(LinearOperator):
         self.explicit = False
 
     def _matvec(self, x):
-        x = x.reshape(self.Op2.shape[1], self.Op1.shape[1])
-        y = self.Op2.matmat(x).T
+        x = x.reshape(self.Op1.shape[1], self.Op2.shape[1])
+        y = self.Op2.matmat(x.T).T
         y = self.Op1.matmat(y).ravel()
         return y
 
     def _rmatvec(self, x):
         x = x.reshape(self.Op1.shape[0], self.Op2.shape[0])
-        y = self.Op1H.matmat(x).T
-        y = self.Op2H.matmat(y).ravel()
+        y = self.Op2H.matmat(x.T).T
+        y = self.Op1H.matmat(y).ravel()
         return y

--- a/pytests/test_kronecker.py
+++ b/pytests/test_kronecker.py
@@ -20,7 +20,7 @@ par2j = {'ny': 21, 'nx': 11,
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
 def test_Kroneker(par):
-    """Dot-test and inversion for Kronecker operator
+    """Dot-test, inversion and comparison with np.kron for Kronecker operator
     """
     np.random.seed(10)
     G1 = np.random.normal(0, 10, (par['ny'], par['nx'])).astype(par['dtype'])
@@ -36,6 +36,11 @@ def test_Kroneker(par):
     xlsqr = lsqr(Kop, Kop * x, damp=1e-20, iter_lim=300, show=0)[0]
     assert_array_almost_equal(x, xlsqr, decimal=2)
 
+    # Comparison with numpy
+    assert_array_almost_equal(np.kron(G1, G2), Kop * np.eye(par['nx']**2),
+                              decimal=3)
+
+
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
 def test_Kroneker_Derivative(par):
     """Use Kronecker operator to apply the Derivative operator over one axis
@@ -47,8 +52,7 @@ def test_Kroneker_Derivative(par):
                            dir=0, sampling=1, edge=True,
                            dtype='float32')
 
-    Kop = Kronecker(Dop,
-                    Identity(par['nx'], dtype=par['dtype']),
+    Kop = Kronecker(Dop, Identity(par['nx'], dtype=par['dtype']),
                     dtype=par['dtype'])
 
     x = np.zeros((par['ny'], par['nx'])) + \

--- a/pytests/test_linearoperator.py
+++ b/pytests/test_linearoperator.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
+from pylops import LinearOperator
 from pylops.basicoperators import MatrixMult, VStack, Diagonal, Zero
 
 par1 = {'ny': 11, 'nx': 11,
@@ -16,6 +17,31 @@ par2j = {'ny': 21, 'nx': 11,
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j)])
+def test_overloads(par):
+    """Apply various overloaded operators (.H, -, +, *) and ensure that the
+    returned operator is still of pylops LinearOperator type
+    """
+    diag = np.arange(par['nx']) +\
+           par['imag'] * np.arange(par['nx'])
+    Dop = Diagonal(diag, dtype=par['dtype'])
+
+    # .H
+    assert isinstance(Dop.H, LinearOperator)
+    # negate
+    assert isinstance(-Dop, LinearOperator)
+    # multiply by scalar
+    assert isinstance(2*Dop, LinearOperator)
+    # +
+    assert isinstance(Dop + Dop, LinearOperator)
+    # -
+    assert isinstance(Dop - 2*Dop, LinearOperator)
+    # *
+    assert isinstance(Dop * Dop, LinearOperator)
+    # **
+    assert isinstance(Dop **2, LinearOperator)
+
+
+@pytest.mark.parametrize("par", [(par1), (par2), (par1j)])
 def test_dense(par):
     """Dense matrix representation
     """
@@ -23,7 +49,7 @@ def test_dense(par):
            par['imag'] * np.arange(par['nx'])
     D = np.diag(diag)
     Dop = Diagonal(diag, dtype=par['dtype'])
-    assert_array_equal(Dop.dense(), D)
+    assert_array_equal(Dop.todense(), D)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j)])

--- a/tutorials/linearoperator.py
+++ b/tutorials/linearoperator.py
@@ -87,8 +87,8 @@ plt.plot(t1, 'k', label=' _matvec')
 plt.plot(t2, 'r', label='matvec')
 plt.plot(t3, 'g', label='@')
 plt.plot(t4, 'b', label='*')
-plt.legend()
 plt.axis('tight')
+plt.legend();
 
 ###############################################################################
 # Similarly we now consider the adjoint mode. This can be done in
@@ -135,26 +135,30 @@ plt.plot(t1, 'k', label=' _rmatvec')
 plt.plot(t2, 'r', label='rmatvec')
 plt.plot(t3, 'g', label='.H* (pre-computed H)')
 plt.plot(t4, 'b', label='.H*')
-plt.legend()
 plt.axis('tight')
+plt.legend();
 
 ###############################################################################
 # Just to reiterate once again, it is advised to call ``matvec``
 # and ``rmatvec`` unless PyLops linear operators are used for
 # teaching purposes.
 #
-# Finally we go through some other *methods* and *special methods* that
+# We now go through some other *methods* and *special methods* that
 # are implemented in :py:class:`scipy.sparse.linalg.LinearOperator` (and
 # :py:class:`pylops.LinearOperator`):
 #
 # * ``Op1+Op2``: maps the special method ``__add__`` and
-#   performs summation between two operators
+#   performs summation between two operators and
+#   returns a :py:class:`pylops.LinearOperator`
 # * ``-Op``: maps the special method ``__neg__`` and
-#   performs negation of an operators
+#   performs negation of an operators and
+#   returns a :py:class:`pylops.LinearOperator`
 # * ``Op1-Op2``: maps the special method ``__sub__`` and
-#   performs summation between two operators
+#   performs summation between two operators and
+#   returns a :py:class:`pylops.LinearOperator`
 # * ``Op1**N``: maps the special method ``__pow__`` and
-#   performs exponentiation of an operator
+#   performs exponentiation of an operator and
+#   returns a :py:class:`pylops.LinearOperator`
 # * ``Op/y`` (and ``Op.div(y)``): maps the special method ``__truediv__`` and
 #   performs inversion of an operator
 # * ``Op.eigs()``: estimates the eigenvalues of the operator
@@ -162,17 +166,17 @@ plt.axis('tight')
 # * ``Op.conj()``: create complex conjugate operator
 
 # +
-print(Dop+Dop)
+print(Dop + Dop)
 
 # -
 print(-Dop)
-print(Dop-0.5*Dop)
+print(Dop - 0.5 * Dop)
 
 # **
-print(Dop**3)
+print(Dop ** 3)
 
 #* and /
-y = Dop*x
+y = Dop * x
 print(Dop/y)
 
 # eigs
@@ -195,33 +199,41 @@ d = 1j*(np.arange(n) + 1.)
 x = np.ones(n)
 Dop = pylops.Diagonal(d)
 
-print('y = Dx', Dop*x)
-print('y = conj(D)x', Dop.conj()*x)
+print('y = Dx = ', Dop*x)
+print('y = conj(D)x = ', Dop.conj()*x)
 
 ###############################################################################
 # At this point, the concept of linear operator may sound abstract.
-# The convinience method :func:`pylops.LinearOperator.dense` can be used to
+# The convinience method :func:`pylops.LinearOperator.todense` can be used to
 # create the equivalent dense matrix of any operator. In this case for example
 # we expect to see a diagonal matrix with ``d`` values along the main diagonal
-D = Dop.dense()
+D = Dop.todense()
 
 plt.figure(figsize=(5, 5))
 plt.imshow(np.abs(D))
 plt.title('Dense representation of Diagonal operator')
 plt.axis('tight')
+plt.colorbar()
 
 ###############################################################################
-# Finally it is worth remembering a useful trick. If two linear operators are
-# combined by means of the algebraical operations shown above, the resulting
-# operator will lose some of the convenience methods (e.g. ``\``) as it will
-# be turned into a :py:class:`scipy.sparse.linalg.LinearOperator` instead of
-# a :py:class:`pylops.LinearOperator`. To transform it back to a PyLops linear
-# operator simply do the following
-Dop1 = Dop + Dop.conj()
-Dop1 = pylops.LinearOperator(Dop, explicit=False)
+# Finally it is worth reiterating that if two linear operators are combined by
+# means of the algebraical operations shown above, the resulting
+# operator is still a :py:class:`pylops.LinearOperator` operator. This means
+# that we can still apply any of the methods implemented in the original
+# scipy class definition like ``*``, as well as those in our class
+# definition like ``/``
+Dop1 = Dop - Dop.conj()
 
 y = Dop1 * x
-print('x = (Dop + conj(Dop))/y', Dop1 / y)
+print('x = (Dop - conj(Dop))/y = ', Dop1 / y)
+
+D1 = Dop1.todense()
+
+plt.figure(figsize=(5, 5))
+plt.imshow(np.abs(D1))
+plt.title(r'Dense representation of $|D + D^*|$')
+plt.axis('tight')
+plt.colorbar()
 
 ###############################################################################
 # This first tutorial is completed. You have seen the basic operations that


### PR DESCRIPTION
The main change in this PR is the fact that now users can sum, subtract, multiply pylops operators and the returned operator maintains all methods and properties as any pylops LinearOperator.

It also contains a bug fix to Kronecker operator ref to #125.