### PR TITLE
[Core] Safeguards for optional dependencies

### DIFF
--- a/pylops/avo/avo.py
+++ b/pylops/avo/avo.py
@@ -43,9 +43,11 @@ def zoeppritz_scattering(vp1, vs1, rho1, vp0, vs0, rho0, theta1):
 
     """
     # Create theta1 array of angles in radiants
-    theta1 = np.radians(np.array(theta1))
-    if theta1.size == 1:
-        theta1 = np.expand_dims(theta1, axis=1)
+    if isinstance(theta1, (int, float)):
+        theta1 = np.array([float(theta1), ])
+    elif isinstance(theta1, (list, tuple)):
+        theta1 = np.array(theta1)
+    theta1 = np.radians(theta1)
 
     # Set the ray parameter p
     p = sin(theta1) / vp1

--- a/pylops/basicoperators/Spread.py
+++ b/pylops/basicoperators/Spread.py
@@ -8,6 +8,10 @@ try:
         _matvec_numba_onthefly, _rmatvec_numba_onthefly
 except ModuleNotFoundError:
     jit = None
+    jit_message = 'Numba not available, reverting to numpy.'
+except Exception as e:
+    jit = None
+    jit_message = 'Failed to import numba (error:%s), use numpy.' % e
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.WARNING)
 
@@ -109,7 +113,7 @@ class Spread(LinearOperator):
             self.engine = 'numba'
         else:
             if engine == 'numba' and jit is None:
-                logging.warning('numba not available, revert to numpy...')
+                logging.warning(jit_message)
             self.engine = 'numpy'
 
         # axes

--- a/pylops/optimization/sparsity.py
+++ b/pylops/optimization/sparsity.py
@@ -11,6 +11,11 @@ try:
     from spgl1 import spgl1
 except ModuleNotFoundError:
     spgl1 = None
+    spgl1_message = 'Spgl1 not installed. ' \
+                    'Run "pip install spgl1".'
+except Exception as e:
+    spgl1 = None
+    spgl1_message = 'Failed to import spgl1 (error:%s).' % e
 
 
 def _softthreshold(x, thresh):
@@ -745,7 +750,7 @@ def SPGL1(Op, data, SOp=None, tau=0, sigma=0, x0=None, **kwargs_spgl1):
 
     """
     if spgl1 is None:
-        raise ModuleNotFoundError('spgl1 not installed')
+        raise ModuleNotFoundError(spgl1_message)
     pinv, _, _, info = \
         spgl1(Op if SOp is None else Op*SOp.H, data,
               tau=tau, sigma=sigma, x0=x0, **kwargs_spgl1)

--- a/pylops/signalprocessing/DWT.py
+++ b/pylops/signalprocessing/DWT.py
@@ -9,6 +9,12 @@ try:
     import pywt
 except ModuleNotFoundError:
     pywt = None
+    pywt_message = 'Pywt package not installed. ' \
+                   'Run "pip install PyWavelets" or ' \
+                   'conda install pywavelets".'
+except Exception as e:
+    pywt = None
+    pywt_message = 'Failed to import pywt (error:%s).' % e
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.WARNING)
 
@@ -87,10 +93,7 @@ class DWT(LinearOperator):
     """
     def __init__(self, dims, dir=0, wavelet='haar', level=1, dtype='float64'):
         if pywt is None:
-            raise ModuleNotFoundError('The wavelet operator requires '
-                                      'the pywt package t be installed. '
-                                      'Run "pip install PyWavelets" or '
-                                      '"conda install pywavelets".')
+            raise ModuleNotFoundError(pywt_message)
         _checkwavelet(wavelet)
 
         if isinstance(dims, int):

--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -6,6 +6,12 @@ try:
     import pyfftw
 except ModuleNotFoundError:
     pyfftw = None
+    pyfftw_message = 'Pyfftw not installed, use numpy or run ' \
+                     '"pip install pyFFTW" or ' \
+                     '"conda install -c conda-forge pyfftw".'
+except Exception as e:
+    pyfftw = None
+    pyfftw_message = 'Failed to import pyfftw (error:%s), use numpy.' % e
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.WARNING)
 
@@ -296,9 +302,9 @@ def FFT(dims, dir=0, nfft=None, sampling=1., real=False,
     if engine == 'fftw' and pyfftw is not None:
         f = _FFT_fftw(dims, dir=dir, nfft=nfft, sampling=sampling,
                       real=real, fftshift=fftshift, dtype=dtype, **kwargs_fftw)
-    elif engine == 'numpy' or pyfftw is None:
+    elif engine == 'numpy' or (engine == 'fftw' and pyfftw is None):
         if engine == 'fftw' and pyfftw is None:
-            logging.warning('use numpy, pyfftw not available...')
+            logging.warning(pyfftw_message)
         f = _FFT_numpy(dims, dir=dir, nfft=nfft, sampling=sampling,
                        real=real, fftshift=fftshift, dtype=dtype)
     else:

--- a/pylops/waveeqprocessing/lsm.py
+++ b/pylops/waveeqprocessing/lsm.py
@@ -10,7 +10,13 @@ try:
     import skfmm
 except ModuleNotFoundError:
     skfmm = None
-
+    skfmm_message = 'Skfmm package not installed. Choose method=analytical ' \
+                    'if using constant velocity or run ' \
+                    '"pip install scikit-fmm" or ' \
+                    '"conda install -c conda-forge scikit-fmm".'
+except Exception as e:
+    skfmm = None
+    skfmm_message = 'Failed to import skfmm (error:%s).' % e
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.WARNING)
 
@@ -141,11 +147,7 @@ def _traveltime_table(z, x, srcs, recs, vel, y=None, mode='eikonal'):
                    trav_recs.reshape(ny * nx * nz, 1, nr)
             trav = trav.reshape(ny * nx * nz, ns * nr)
         else:
-            raise NotImplementedError('cannot compute traveltime with '
-                                      'method=eikonal as skfmm is not '
-                                      'installed... choose analytical'
-                                      'if using constant velocity model, '
-                                      'or install scikit-fmm library')
+            raise NotImplementedError(skfmm_message)
     else:
         raise NotImplementedError('method must be analytic or eikonal')
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,8 @@ scipy>=1.1.0
 numba
 pyfftw
 PyWavelets
-scikit-fmm
 spgl1
+scikit-fmm
 matplotlib
 ipython
 pytest


### PR DESCRIPTION
- Add safeguards when importing optional dependencies to avoid that changes in mandatory dependencies may affect an optional dependencies and lead to an error when loading it within pylops. If the dependency cannot be loaded pylops will still be able to work without it.
- Temporarily remove tests using skfmm for OSX.
