### PR TITLE
Substitute x / np.abs(x) by np.sign(x)

### DIFF
--- a/pylops/optimization/sparsity.py
+++ b/pylops/optimization/sparsity.py
@@ -181,20 +181,6 @@ def _halfthreshold_percentile(x, perc):
     #return _halfthreshold(x, (2. / 3. * thresh) ** (1.5))
     return _halfthreshold(x, (4. / 54 ** (1. / 3.) * thresh) ** 1.5)
 
-def _shrinkage(x, thresh):
-    r"""Shrinkage.
-
-    Applies shrinkage to vector ``x``.
-
-    Parameters
-    ----------
-    x : :obj:`numpy.ndarray`
-        Vector
-    thresh : :obj:`float`
-        Threshold
-    """
-    return np.maximum(np.abs(x) - thresh, 0.) * np.exp(1j * np.angle(x))
-
 
 def _IRLS_data(Op, data, nouter, threshR=False, epsR=1e-10,
                epsI=1e-10, x0=None, tolIRLS=1e-10,
@@ -1323,7 +1309,7 @@ def SplitBregman(Op, RegsL1, data, niter_outer=3, niter_inner=5, RegsL2=None,
                                         x0=x0 if restart else xinv,
                                         **kwargs_lsqr)
             # Shrinkage
-            d = [_shrinkage(RegsL1[ireg] * xinv + b[ireg], epsRL1s[ireg])
+            d = [_softthreshold(RegsL1[ireg] * xinv + b[ireg], epsRL1s[ireg])
                  for ireg in range(nregsL1)]
         # Bregman update
         b = [b[ireg] + tau * (RegsL1[ireg] * xinv - d[ireg]) for ireg in

--- a/pylops/optimization/sparsity.py
+++ b/pylops/optimization/sparsity.py
@@ -75,7 +75,7 @@ def _softthreshold(x, thresh):
     #    x1 = np.maximum(np.abs(x) - thresh, 0.) * np.exp(1j * np.angle(x))
     #else:
     #    x1 = np.maximum(np.abs(x)-thresh, 0.) * np.sign(x)
-    x1 = x - thresh * x / np.abs(x)
+    x1 = x - thresh * np.sign(x)
     x1[np.abs(x) <= thresh] = 0
     return x1
 
@@ -200,7 +200,7 @@ def _shrinkage(x, thresh):
         Threshold
     """
     xabs = np.abs(x)
-    return x/(xabs+1e-10) * np.maximum(xabs - thresh, 0)
+    return np.sign(x) * np.maximum(xabs - thresh, 0)
 
 
 def _IRLS_data(Op, data, nouter, threshR=False, epsR=1e-10,

--- a/pylops/optimization/sparsity.py
+++ b/pylops/optimization/sparsity.py
@@ -69,15 +69,9 @@ def _softthreshold(x, thresh):
         Tresholded vector
 
     """
-    #if np.iscomplexobj(x):
-    #    # https://stats.stackexchange.com/questions/357339/soft-thresholding-
-    #    # for-the-lasso-with-complex-valued-data
-    #    x1 = np.maximum(np.abs(x) - thresh, 0.) * np.exp(1j * np.angle(x))
-    #else:
-    #    x1 = np.maximum(np.abs(x)-thresh, 0.) * np.sign(x)
-    x1 = x - thresh * np.sign(x)
-    x1[np.abs(x) <= thresh] = 0
-    return x1
+    # https://stats.stackexchange.com/questions/357339/soft-thresholding-
+    # for-the-lasso-with-complex-valued-data
+    return np.maximum(np.abs(x) - thresh, 0.) * np.exp(1j * np.angle(x))
 
 def _halfthreshold(x, thresh):
     r"""Half thresholding.
@@ -199,8 +193,7 @@ def _shrinkage(x, thresh):
     thresh : :obj:`float`
         Threshold
     """
-    xabs = np.abs(x)
-    return np.sign(x) * np.maximum(xabs - thresh, 0)
+    return np.maximum(np.abs(x) - thresh, 0.) * np.exp(1j * np.angle(x))
 
 
 def _IRLS_data(Op, data, nouter, threshR=False, epsR=1e-10,


### PR DESCRIPTION
Ran into floating point exeptions using ISTA and FISTA because of the division in `_softthreshold`. Changed `_shrinkage` as well which did have protection from division by zero, but was ugly.